### PR TITLE
implement better dvh fallbacks using not supports

### DIFF
--- a/src/components/ChatHistory.vue
+++ b/src/components/ChatHistory.vue
@@ -74,24 +74,24 @@
       </div>
     </div>
     </div>
-    <!-- Add the clear localStorage button at the bottom -->
-    <button
-      @click="clearLocalStorage"
-      class="clear-storage-button"
-    >
-      <font-awesome-icon
-        icon="trash"
-        class="base-icon"
-      />
-      <span
-        v-if="isVisible"
-        class="ml-2"
-      >Clear localStorage</span>
-    </button>
-    <p
-      v-if="isVisible"
-      class="text-center text-italic text-sm text-hint"
-    >Having issues? Try clearing localStorage.</p>
+    <div class="mt-auto">
+      <p
+        class="text-center text-italic text-hint"
+      >Having issues? Try clearing localStorage.</p>
+      <button
+        @click="clearLocalStorage"
+        class="clear-storage-button"
+      >
+        <font-awesome-icon
+          icon="trash"
+          class="base-icon"
+        />
+        <span
+          v-if="isVisible"
+          class="ml-2"
+        >Clear localStorage</span>
+      </button>
+    </div>
   </div>
 </template>
 
@@ -444,5 +444,6 @@ export default {
 .text-hint {
   color: #9ca3af;
   margin-top: 0.5rem;
+  font-size: 12px;
 }
 </style>

--- a/src/components/HeroBanner.vue
+++ b/src/components/HeroBanner.vue
@@ -48,12 +48,17 @@ export default {
 
 <style>
 .hero-banner {
-  min-height: 100vh;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: v-bind(backgroundColor);
+}
+
+@supports not (height: 100dvh) {
+  .hero-banner {
+    min-height: 100vh;
+  }
 }
 
 @supports (height: 100dvh) {

--- a/src/components/PageSection.vue
+++ b/src/components/PageSection.vue
@@ -65,11 +65,13 @@ export default {
   margin: 0 auto;
 }
 
-
-.page-section--full-height {
-  min-height: calc(100vh - var(--site-header-height) + var(--space-5));
-
+@supports not (height: 100dvh) {
+  .page-section--full-height {
+    min-height: calc(100vh - var(--site-header-height) + var(--space-5));
+  }
 }
+
+
 @supports (height: 100dvh) {
   .page-section--full-height {
     min-height: calc(100dvh - var(--site-header-height) + var(--space-5));

--- a/src/components/ParallaxSection.vue
+++ b/src/components/ParallaxSection.vue
@@ -113,7 +113,12 @@ export default {
   justify-content: center;
   padding: 4rem 1.5rem;
   overflow: hidden;
-  min-height: 100vh;
+}
+
+@supports not (height: 100dvh) {
+  .parallax-section {
+    min-height: 100vh;
+  }
 }
 
 @supports (height: 100dvh) {

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -387,6 +387,12 @@ export default {
   z-index: 1000;
 }
 
+@supports not (height: 100dvh) {
+  .site-header__mobile-nav {
+    height: 100vh;
+  }
+}
+
 @supports (height: 100dvh) {
   .site-header__mobile-nav {
     height: 100dvh;

--- a/src/pages/nick-ai.astro
+++ b/src/pages/nick-ai.astro
@@ -31,9 +31,14 @@ import PageSection from '../components/PageSection.vue';
 <style>
     .chat-layout {
         display: flex;
-        height: 100vh;
         overflow: hidden;
     }
+    @supports not (height: 100dvh) {
+      .chat-layout {
+        height: 100vh;
+      }
+    }
+
     @supports (height: 100dvh) {
       .chat-layout {
         height: 100dvh;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved support for dynamic viewport height units across multiple components and pages, ensuring more consistent layout heights on different browsers and devices.
  * Added fallbacks for browsers that do not support the `100dvh` unit, enhancing visual consistency for banners, sections, mobile navigation, and chat layouts.
  * Updated chat history interface to always display hint text with adjusted font size and reorganized button placement for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->