### PR TITLE
Add Google Analytics tracking to site

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -18,18 +18,23 @@ const {
 // Resolve absolute image URL from the current site origin (or configured Astro.site)
 const base = Astro.site?.origin || Astro.url.origin;
 const ogImgUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, base).href;
+const gaTrackingId = import.meta.env.PUBLIC_GA_TRACKING_ID;
 ---
 
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YRSSE66Z31"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  {gaTrackingId && (
+    <>
+      <!-- Google tag (gtag.js) -->
+      <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}></script>
+      <script define:vars={{ gaTrackingId }}>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    gtag('config', 'G-YRSSE66Z31');
-  </script>
+        gtag('config', gaTrackingId);
+      </script>
+    </>
+  )}
 
   <meta charset="utf-8" />
   <link rel="icon" type="image/svg+xml" href={favicon} />


### PR DESCRIPTION
Add Google Analytics gtag.js script to Head component to track site usage and analytics. Script is placed immediately after <head> element as per Google's instructions.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated Google Analytics to enable site usage tracking.
  * Loads the analytics script asynchronously to minimize performance impact.
  * Initializes tracking and a data layer to collect page metrics.
  * Does not alter existing meta tags, SEO settings, or visible UI.
  * Existing page content and functionality remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->