### PR TITLE
fix: use dynamic PORT in healthcheck to match Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,9 @@ USER app
 # Expose port
 EXPOSE 8000
 
-# Healthcheck to verify the app is running
+# Healthcheck to verify the app is running - use PORT env var if set
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+  CMD python3 -c "import urllib.request, os; urllib.request.urlopen(f'http://localhost:{os.environ.get(\"PORT\", \"8000\")}/health')" || exit 1
 
 # Production command - use PORT env var if provided (Railway sets this)
 CMD uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
Railway assigns a dynamic PORT environment variable, but the healthcheck was hardcoded to check localhost:8000, causing deployment failures.

🤖 Generated with [Claude Code](https://claude.ai/code)