### PR TITLE
fix: convert LLM topic lists to strings for ChromaDB compatibility

### DIFF
--- a/backend/core/startup_content_classifier.py
+++ b/backend/core/startup_content_classifier.py
@@ -73,8 +73,8 @@ class StartupContentClassifier:
             "content_keywords": keywords,
             "topic_confidence": confidence,
             "classification_method": "startup_llm",
-            "llm_topics": llm_topics,
-            "heuristic_topics": heuristic_topics,
+            "llm_topics": ",".join(llm_topics) if llm_topics else "",
+            "heuristic_topics": ",".join(heuristic_topics) if heuristic_topics else "",
             **special_metadata,
         }
 


### PR DESCRIPTION
## Summary
- Fixed ChromaDB metadata validation error in production deployment
- Convert LLM topic classification lists to comma-separated strings
- Resolves: "Expected metadata value to be a str, int, float, bool, or None, got [...] which is a list"

## Root Cause
The `StartupContentClassifier` was storing Python lists directly in ChromaDB metadata:
```python
"llm_topics": llm_topics,  # This was a list!
"heuristic_topics": heuristic_topics,  # This was a list!
```

ChromaDB only accepts primitive types (string, int, float, bool, None) in metadata.

## Fix Applied
Convert lists to comma-separated strings:
```python
"llm_topics": ",".join(llm_topics) if llm_topics else "",
"heuristic_topics": ",".join(heuristic_topics) if heuristic_topics else "",
```

## Why This Worked Locally But Failed in Production
- **Local**: Likely using `FastContentClassifier` (no LLM calls, no lists)
- **Production**: Valid `ANTHROPIC_API_KEY` → `StartupContentClassifier` → LLM calls → lists stored → ChromaDB error

## Test Plan
- [x] Verified metadata conversion works correctly
- [x] Tested that strings are properly stored instead of lists
- [x] Ready for production deployment

🤖 Generated with [Claude Code](https://claude.ai/code)