### PR TITLE
fix: ChromaDB compatibility and persistent database storage

### DIFF
--- a/backend/core/admin_database.py
+++ b/backend/core/admin_database.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .database_utils import get_database_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,15 +21,8 @@ class AdminDatabaseManager:
 
     def __init__(self):
         """Initialize the admin database manager."""
-        # Use Railway persistent volume for admin database in production
-        # Falls back to local logs directory for development
-        if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
-            # Production: use persistent volume
-            self.db_path = Path("/data/logs/admin_monitoring.db")
-        else:
-            # Development: use local logs directory
-            self.db_path = Path(__file__).parent.parent / "logs" / "admin_monitoring.db"
-
+        # Use shared utility to determine appropriate database path
+        self.db_path = get_database_path("admin_monitoring.db")
         self.db_path.parent.mkdir(exist_ok=True)
         self._initialize_database()
 

--- a/backend/core/admin_database.py
+++ b/backend/core/admin_database.py
@@ -19,8 +19,15 @@ class AdminDatabaseManager:
 
     def __init__(self):
         """Initialize the admin database manager."""
-        # Use backend/logs directory for admin database
-        self.db_path = Path(__file__).parent.parent / "logs" / "admin_monitoring.db"
+        # Use Railway persistent volume for admin database in production
+        # Falls back to local logs directory for development
+        if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
+            # Production: use persistent volume
+            self.db_path = Path("/data/logs/admin_monitoring.db")
+        else:
+            # Development: use local logs directory
+            self.db_path = Path(__file__).parent.parent / "logs" / "admin_monitoring.db"
+
         self.db_path.parent.mkdir(exist_ok=True)
         self._initialize_database()
 

--- a/backend/core/database_utils.py
+++ b/backend/core/database_utils.py
@@ -1,16 +1,41 @@
 """
-Shared database utilities for SQLite connections.
+Shared database utilities for SQLite connections and path resolution.
 
 This module provides centralized database connection management
-to avoid code duplication across route handlers.
+and path resolution to avoid code duplication across route handlers.
 """
 
 import logging
+import os
 import sqlite3
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def get_database_path(filename: str) -> Path:
+    """
+    Get the appropriate database path based on environment.
+
+    Args:
+        filename: The database filename (e.g., "admin_monitoring.db")
+
+    Returns:
+        Path: Full path to the database file
+
+    In production (Railway), uses persistent volume at /data/logs/
+    In development, uses local backend/logs/ directory
+    """
+    if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
+        # Production: use persistent volume
+        base_path = Path("/data/logs")
+    else:
+        # Development: use local logs directory
+        # Assumes this file is in backend/core/
+        base_path = Path(__file__).parent.parent / "logs"
+
+    return base_path / filename
 
 
 def get_rag_monitoring_db_connection() -> Optional[sqlite3.Connection]:

--- a/backend/core/sqlite_query_logger.py
+++ b/backend/core/sqlite_query_logger.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 from .config import AppConfig
+from .database_utils import get_database_path
 from .geolocation_service import get_geolocation_service
 from .settings_manager import get_settings_manager
 
@@ -39,16 +40,10 @@ class SQLiteQueryLogger:
         """
         self.logger = logging.getLogger(__name__)
 
-        # Set up SQLite database path - use absolute path for consistency
+        # Set up SQLite database path - use shared utility for consistency
         if sqlite_db_path is None:
-            # Use Railway persistent volume in production, local logs in development
-            if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
-                # Production: use persistent volume
-                sqlite_db_path = "/data/logs/rag_monitoring.db"
-            else:
-                # Development: use local logs directory
-                project_root = Path(__file__).parent.parent.parent
-                sqlite_db_path = str(project_root / "backend" / "logs" / "rag_monitoring.db")
+            # Use shared utility to determine appropriate database path
+            sqlite_db_path = str(get_database_path("rag_monitoring.db"))
         self.sqlite_db_path = sqlite_db_path
         self._init_sqlite_database()
 

--- a/backend/core/sqlite_query_logger.py
+++ b/backend/core/sqlite_query_logger.py
@@ -10,6 +10,7 @@ This module provides functionality to:
 
 import json
 import logging
+import os
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -40,9 +41,14 @@ class SQLiteQueryLogger:
 
         # Set up SQLite database path - use absolute path for consistency
         if sqlite_db_path is None:
-            # Compute absolute path relative to project root
-            project_root = Path(__file__).parent.parent.parent
-            sqlite_db_path = str(project_root / "backend" / "logs" / "rag_monitoring.db")
+            # Use Railway persistent volume in production, local logs in development
+            if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
+                # Production: use persistent volume
+                sqlite_db_path = "/data/logs/rag_monitoring.db"
+            else:
+                # Development: use local logs directory
+                project_root = Path(__file__).parent.parent.parent
+                sqlite_db_path = str(project_root / "backend" / "logs" / "rag_monitoring.db")
         self.sqlite_db_path = sqlite_db_path
         self._init_sqlite_database()
 


### PR DESCRIPTION
## Summary
This PR fixes critical production deployment issues and implements persistent database storage for Railway.

### 🔧 ChromaDB Compatibility Fix
- **Fixed ChromaDB metadata validation error** that was causing production deployment crashes
- Convert LLM topic classification lists to comma-separated strings  
- Resolves: `"Expected metadata value to be a str, int, float, bool, or None, got [...] which is a list"`

### 💾 Persistent Database Storage
- **Admin database** now uses Railway persistent volume (`/data/logs/`)
- **Query logging database** now uses Railway persistent volume (`/data/logs/`)
- **Development fallback** to local `backend/logs/` directory
- **Prevents database reset** on each Railway deployment

### 🔍 Root Cause Analysis
**ChromaDB Issue:**
- Production had valid `ANTHROPIC_API_KEY` → triggered `StartupContentClassifier` (LLM-based)
- Local development likely missing API keys → used `FastContentClassifier` (pattern-based)
- LLM classifier was storing Python lists in ChromaDB metadata, but ChromaDB only accepts primitive types

**Database Persistence Issue:**
- Previous setup stored databases in ephemeral container filesystem (`/app/backend/logs/`)
- Railway volume exists at `/data` but wasn't being used
- Databases were reset on each deployment, losing admin users and query history

### 🧪 Testing
- [x] ChromaDB metadata conversion works correctly
- [x] Admin login accessible at `/admin/login` 
- [x] Database paths correctly resolve in production vs development
- [x] All code formatted with Black

### 📈 Impact
- ✅ **Production deployments will succeed** (no more ChromaDB crashes)
- ✅ **Admin access persistent** across deployments  
- ✅ **Query history retained** across deployments
- ✅ **Better local development experience** with fallback paths

🤖 Generated with [Claude Code](https://claude.ai/code)