### PR TITLE
fix: use Railway volume root /data instead of /data/logs for database…

### DIFF
--- a/backend/core/database_utils.py
+++ b/backend/core/database_utils.py
@@ -24,12 +24,13 @@ def get_database_path(filename: str) -> Path:
     Returns:
         Path: Full path to the database file
 
-    In production (Railway), uses persistent volume at /data/logs/
+    In production (Railway), uses persistent volume at /data/
     In development, uses local backend/logs/ directory
     """
     if os.getenv("RAILWAY_ENVIRONMENT_NAME"):
-        # Production: use persistent volume
-        base_path = Path("/data/logs")
+        # Production: use persistent volume directly at /data (not /data/logs)
+        # Railway mounts the volume at /data and we have permission there
+        base_path = Path("/data")
     else:
         # Development: use local logs directory
         # Assumes this file is in backend/core/


### PR DESCRIPTION
… storage

- Change production database path from /data/logs to /data
- Railway volume is mounted at /data with proper app user permissions
- Creating subdirectories under volume mount can cause permission issues
- Database files will be stored directly in /data volume for production

Fixes sqlite3.OperationalError: unable to open database file

🤖 Generated with [Claude Code](https://claude.ai/code)