### PR TITLE
Fix admin dashboard rate limiting causing 429 errors

### DIFF
--- a/backend/core/app_factory.py
+++ b/backend/core/app_factory.py
@@ -86,6 +86,10 @@ async def dynamic_rate_limit_middleware(request: Request, call_next):
     if _is_testing:
         return await call_next(request)
 
+    # Skip rate limiting for admin routes - they have session-based auth protection
+    if request.url.path.startswith("/admin/") or request.url.path.startswith("/api/admin/"):
+        return await call_next(request)
+
     try:
         settings_manager = get_settings_manager()
         security_settings = settings_manager.get_security_settings()


### PR DESCRIPTION
- Exempt admin routes (/admin/* and /api/admin/*) from dynamic rate limiting middleware
- Admin routes already have session-based authentication protection
- Resolves 429 (Too Many Requests) errors when loading admin dashboard
- Multiple rapid admin API calls no longer trigger rate limiting

🤖 Generated with [Claude Code](https://claude.ai/code)