### PR TITLE
fix: resolve admin frontend 404 errors in production

### DIFF
--- a/admin/frontend/package.json
+++ b/admin/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --mode production",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "lint:fix": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "backend:stop": "podman stop nickberens || true",
     "admin:backend": "python3 admin/start-admin.py",
     "admin:frontend": "cd admin/frontend && npm run dev",
-    "admin:build": "cd admin/frontend && npm run build",
+    "admin:build": "cd admin/frontend && NODE_ENV=production npm run build",
     "admin": "npm run admin:frontend",
     "admin:stop": "pkill -f 'python3 admin/start-admin.py' || true",
     "admin:sync": "python3 admin/sync_logs.py",
@@ -25,7 +25,7 @@
     "e2e:ui": "cd tests/e2e && npx -y @playwright/mcp@latest test --ui",
     "e2e:report": "cd tests/e2e && npx -y @playwright/mcp@latest show-report",
     "e2e:install": "cd tests/e2e && npx -y @playwright/mcp@latest install",
-    "railway:build": "./scripts/copy-content-to-knowledge.sh && cd admin/frontend && npm ci && npm run build",
+    "railway:build": "./scripts/copy-content-to-knowledge.sh && cd admin/frontend && npm ci && NODE_ENV=production npm run build",
     "railway:deploy": "railway up"
   },
   "dependencies": {


### PR DESCRIPTION
- Update admin frontend build to use production mode explicitly
- Configure Railway build script to set NODE_ENV=production
- Ensure .env.production is loaded with correct VITE_API_BASE_URL=/api/admin
- Fix admin authentication endpoints from /auth/* to /api/admin/auth/*

This resolves 404 errors where admin frontend was making requests to /auth/login instead of /api/admin/auth/login in production.

🤖 Generated with [Claude Code](https://claude.ai/code)