### PR TITLE
feat: add API key migration support and disable ChromaDB telemetry

### DIFF
--- a/backend/core/api_key_manager.py
+++ b/backend/core/api_key_manager.py
@@ -70,14 +70,52 @@ class ApiKeyManager:
             raise
 
     def decrypt_key(self, encrypted_value: str) -> str:
-        """Decrypt an API key."""
+        """Decrypt an API key.
+
+        Supports both new (Fernet-encrypted, base64-encoded) values and
+        legacy values that were stored as base64-encoded plaintext during
+        environment migration. If a legacy format is detected, we transparently
+        return the decoded value and attempt a best-effort in-place migration
+        to the new encryption format.
+        """
+        # First, base64-decode the stored string
         try:
-            # Decode from base64 and decrypt
-            encrypted = base64.b64decode(encrypted_value.encode("utf-8"))
-            decrypted = self.cipher.decrypt(encrypted)
-            return decrypted.decode("utf-8")
+            raw = base64.b64decode(encrypted_value.encode("utf-8"))
         except Exception as e:
-            logger.error(f"Error decrypting API key: {e}")
+            logger.error(f"Error base64-decoding stored API key value: {e}")
+            raise
+
+        # Attempt Fernet decryption (new format)
+        try:
+            decrypted = self.cipher.decrypt(raw)
+            return decrypted.decode("utf-8")
+        except Exception as fernet_error:
+            # Fallback: legacy format (raw is actually the plaintext API key)
+            try:
+                legacy_plain = raw.decode("utf-8", errors="ignore").strip()
+            except Exception:
+                legacy_plain = ""
+
+            if legacy_plain and len(legacy_plain) >= 10:
+                logger.warning("Detected legacy base64-only API key format; using decoded value and migrating")
+                # Attempt one-shot in-place migration to new encrypted format
+                try:
+                    new_encrypted_b64, _last_four = self.encrypt_key(legacy_plain)
+                    from .admin_database import admin_db_manager  # local import to avoid cycles at module import
+
+                    with admin_db_manager.get_connection() as conn:
+                        cur = conn.cursor()
+                        cur.execute(
+                            "UPDATE api_keys SET encrypted_value = ?, updated_at = CURRENT_TIMESTAMP WHERE encrypted_value = ?",
+                            (new_encrypted_b64, encrypted_value),
+                        )
+                except Exception as migrate_error:
+                    # Non-fatal: we can still return the usable key
+                    logger.debug(f"API key migration to new encryption failed (non-fatal): {migrate_error}")
+                return legacy_plain
+
+            # If fallback failed, surface the original error for observability
+            logger.error(f"Error decrypting API key with Fernet: {fernet_error}")
             raise
 
     def create_api_key(self, key_name: str, key_type: str, api_key: str, updated_by: int) -> Dict[str, Any]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ This is the main entry point for the FastAPI application that:
 """
 
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -15,6 +16,13 @@ from typing import Any, Dict, Optional
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from langchain_core.language_models import BaseLanguageModel
+
+# Disable ChromaDB telemetry early to avoid noisy PostHog errors in some environments
+# Set several known flags to be safe across versions
+os.environ.setdefault("CHROMADB_TELEMETRY", "false")
+os.environ.setdefault("CHROMA_TELEMETRY", "false")
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
+os.environ.setdefault("POSTHOG_DISABLED", "1")
 
 from .core.app_factory import create_app
 from .core.app_initializer_v2 import initialize_app_state


### PR DESCRIPTION
- Add legacy API key format support with automatic migration in api_key_manager.py
- Implement backward compatibility for base64-only encrypted keys
- Add best-effort in-place migration to new Fernet encryption format
- Disable ChromaDB telemetry early in main.py to prevent PostHog errors
- Improve error handling and logging for API key operations

🤖 Generated with [Claude Code](https://claude.ai/code)