### PR TITLE
add development netlify branch to allowed cors

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -377,6 +377,7 @@ class AppConfig:
             "http://localhost:8001",
             "http://localhost:8002",
             "http://localhost:8003",
+            "https://devserver-development--nickberens360.netlify.app",
         ]
 
         if environment in ["production", "prod"]:


### PR DESCRIPTION
This pull request makes a minor configuration update to the backend CORS settings. The change adds a new allowed origin for development environments.

* Development configuration: Added `https://devserver-development--nickberens360.netlify.app` to the list of allowed CORS origins in the `get_cors_origins` function in `backend/core/config.py`.