### PR TITLE
add development netlify branch to allowed cors

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -361,6 +361,7 @@ class AppConfig:
             "https://nickberens.me",
             "https://www.nickberens.me",
             "https://nickberens360.netlify.app",
+            "https://development--nickberens360.netlify.app",
             "https://nickberens-astro.onrender.com",
             "https://nickberens-astro-production.up.railway.app",
             "https://nickberens-astro-development.up.railway.app",
@@ -377,7 +378,7 @@ class AppConfig:
             "http://localhost:8001",
             "http://localhost:8002",
             "http://localhost:8003",
-            "https://devserver-development--nickberens360.netlify.app",
+            "https://development--nickberens360.netlify.app",
         ]
 
         if environment in ["production", "prod"]:


### PR DESCRIPTION
This pull request updates the list of allowed CORS origins in the `get_cors_origins` function to better support development and deployment environments. The main changes are focused on ensuring that the correct Netlify development domain is included for both general and devserver-specific use cases.

CORS configuration updates:

* Added `https://development--nickberens360.netlify.app` to the list of allowed origins for general access, supporting development deployments on Netlify.
* Replaced the previous devserver-specific Netlify domain with `https://development--nickberens360.netlify.app` to standardize the allowed origin for development environments.